### PR TITLE
Use GitHub Cache API for build-image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -52,5 +52,5 @@ jobs:
         push: ${{ github.ref == 'refs/heads/master' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=registry,ref=ghcr.io/sksat/kuso-subdomain-adder:buildcache
-        cache-to: type=registry,ref=ghcr.io/sksat/kuso-subdomain-adder:buildcache,mode=max
+        cache-from: type=gha
+        cache-to: type=gha,mode=max


### PR DESCRIPTION
Fix #70 (2回目)