### PR TITLE
Renovate group for Rust

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,11 @@
       "depNameTemplate": "rust",
       "lookupNameTemplate": "rust-lang/rust",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "groupName": "Rust",
+      "groupSlug": "rust",
+      "packageNames": ["rust", "ghcr.io/sksat/cargo-chef-docker"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,13 @@
     "config:base"
   ],
   "lockFileMaintenance": { "enabled": true },
+  "packageRules": [
+    {
+      "groupName": "Rust",
+      "groupSlug": "rust",
+      "packageNames": ["rust", "ghcr.io/sksat/cargo-chef-docker"]
+    }
+  ],
   "regexManagers": [
     {
       "fileMatch": ["^rust-toolchain(\\.toml)?$"],
@@ -12,11 +19,6 @@
       "depNameTemplate": "rust",
       "lookupNameTemplate": "rust-lang/rust",
       "datasourceTemplate": "github-releases"
-    },
-    {
-      "groupName": "Rust",
-      "groupSlug": "rust",
-      "packageNames": ["rust", "ghcr.io/sksat/cargo-chef-docker"]
     }
   ]
 }


### PR DESCRIPTION
これpackage nameをrustにしてまとめるべきなんだなあ

_Originally posted by @sksat in https://github.com/sksat/kuso-subdomain-adder/issues/183#issuecomment-991490825_

`matchStrings`でやんないといけないかと思ったけどgroupなる欲しいやつそのままの機能があった(まあそりゃそうだ)