### PR TITLE
remove cargo-make --version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,6 @@ jobs:
       - name: install cargo-make
         uses: sksat/rust-cargo-make@add-makers
 
-      - name: check cargo-make version
-        run: |
-          cargo-make --version
-          cargo-make make --version
-          makers --version
-
       - name: cache dependencies
         uses: Swatinem/rust-cache@v1.3.0
 


### PR DESCRIPTION
latestのcargo-makeは`cargo-make --version`を受け付けなくなった(cargo subcommandとしてではなく起動されることを考えていない)っぽい．

https://github.com/sksat/kuso-subdomain-adder/runs/4804902655?check_suite_focus=true