### PR TITLE
Fix Rust CI triiger on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,11 @@
 name: CI
 
 on:
-  pull_request:
-    paths:
-      - 'src/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain'
-      - '.github/workflows/ci.yml'
   push:
     branches:
       - master
       - dev-*
+  pull_request:
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
#377 とか #376 で走らなくて困る & protected branchのrequiredにしてるので